### PR TITLE
#1993: support storing whole objects in select

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -83,7 +83,7 @@ An array of objects with arbitrary properties. Each property may have any inputs
 
 ### Complex List Arguments
 
-* **props** an array of objects, represending the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
+* **props** an array of objects, representing the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
 
 ### Complex List Usage
 
@@ -91,7 +91,7 @@ An array of objects with arbitrary properties. Each property may have any inputs
 * Items can be added by clicking the `add` button
 * When a complex-list is _not_ empty, the focused item will have actions it, with `add` and `remove` buttons
 * Items can be removed by clicking the `remove` button
-* Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list.
+* Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list, except before the first item.
 
 ```yaml
 links:
@@ -407,8 +407,10 @@ An enhanced browser `<select>` element, allowing the user to select one (or more
 
 * **multiple** - allow multiple options to be selected. data will be an object with options as keys, similar to checkbox-group
 * **search** - allow users to type stuff in to filter options. Extremely useful for longer options lists
-* **list** - The key `list`  is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
+* **list** - The key `list` is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
 * **options** - an array of strings or objects (with `name`, `value`, and optionally `sites`)
+* **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists
+* **storeRawData** normally only the `value` of each option is stored, but with this option you can store the entire input object
 * **help** - description / helper text for the field
 * **attachedButton** - an icon button that should be attached to the field, to allow additional functionality
 * **validate.required** - either `true` or an object that described the conditions that should make this field required

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -83,7 +83,7 @@ An array of objects with arbitrary properties. Each property may have any inputs
 
 ### Complex List Arguments
 
-* **props** an array of objects, representing the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
+* **props** an array of objects, represending the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
 
 ### Complex List Usage
 
@@ -91,7 +91,7 @@ An array of objects with arbitrary properties. Each property may have any inputs
 * Items can be added by clicking the `add` button
 * When a complex-list is _not_ empty, the focused item will have actions it, with `add` and `remove` buttons
 * Items can be removed by clicking the `remove` button
-* Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list, except before the first item.
+* Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list.
 
 ```yaml
 links:
@@ -409,7 +409,7 @@ An enhanced browser `<select>` element, allowing the user to select one (or more
 * **search** - allow users to type stuff in to filter options. Extremely useful for longer options lists
 * **list** - The key `list` is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
 * **options** - an array of strings or objects (with `name`, `value`, and optionally `sites`)
-* **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists
+* **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists. Defaults to `{label: 'name', value: 'value'}`
 * **storeRawData** normally only the `value` of each option is stored, but with this option you can store the entire input object
 * **help** - description / helper text for the field
 * **attachedButton** - an icon button that should be attached to the field, to allow additional functionality

--- a/inputs/complex-list.vue
+++ b/inputs/complex-list.vue
@@ -5,7 +5,7 @@
 
   ### Complex List Arguments
 
-  * **props** an array of objects, representing the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
+  * **props** an array of objects, represending the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
 
   ### Complex List Usage
 
@@ -13,7 +13,7 @@
   * Items can be added by clicking the `add` button
   * When a complex-list is _not_ empty, the focused item will have actions it, with `add` and `remove` buttons
   * Items can be removed by clicking the `remove` button
-  * Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list, except before the first item.
+  * Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list.
 
   ```yaml
   links:

--- a/inputs/complex-list.vue
+++ b/inputs/complex-list.vue
@@ -5,7 +5,7 @@
 
   ### Complex List Arguments
 
-  * **props** an array of objects, represending the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
+  * **props** an array of objects, representing the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
 
   ### Complex List Usage
 
@@ -13,7 +13,7 @@
   * Items can be added by clicking the `add` button
   * When a complex-list is _not_ empty, the focused item will have actions it, with `add` and `remove` buttons
   * Items can be removed by clicking the `remove` button
-  * Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list.
+  * Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list, except before the first item.
 
   ```yaml
   links:

--- a/inputs/select.vue
+++ b/inputs/select.vue
@@ -9,7 +9,7 @@
   * **search** - allow users to type stuff in to filter options. Extremely useful for longer options lists
   * **list** - The key `list` is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
   * **options** - an array of strings or objects (with `name`, `value`, and optionally `sites`)
-  * **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists
+  * **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists. Defaults to `{label: 'name', value: 'value'}`
   * **storeRawData** normally only the `value` of each option is stored, but with this option you can store the entire input object
   * **help** - description / helper text for the field
   * **attachedButton** - an icon button that should be attached to the field, to allow additional functionality
@@ -108,7 +108,7 @@
     computed: {
       keys () {
         return {
-          label: 'name', // backwards compatibility I guess?
+          label: 'name',
           value: 'value',
           ...this.args.keys
         }

--- a/inputs/select.vue
+++ b/inputs/select.vue
@@ -7,8 +7,10 @@
 
   * **multiple** - allow multiple options to be selected. data will be an object with options as keys, similar to checkbox-group
   * **search** - allow users to type stuff in to filter options. Extremely useful for longer options lists
-  * **list** - The key `list`  is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
+  * **list** - The key `list` is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
   * **options** - an array of strings or objects (with `name`, `value`, and optionally `sites`)
+  * **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists
+  * **storeRawData** normally only the `value` of each option is stored, but with this option you can store the entire input object
   * **help** - description / helper text for the field
   * **attachedButton** - an icon button that should be attached to the field, to allow additional functionality
   * **validate.required** - either `true` or an object that described the conditions that should make this field required
@@ -59,7 +61,8 @@
   <ui-select
     v-if="hasOptions"
     :name="name"
-    :value="safeData"
+    :value="value"
+    :keys="keys"
     :options="options"
     :multiple="args.multiple"
     :hasSearch="args.search"
@@ -70,9 +73,11 @@
     :error="errorMessage"
     :invalid="isInvalid"
     iconPosition="right"
-    @input="update">
+    @input="handleInput"
+  >
     <attached-button slot="icon" :name="name" :data="data" :schema="schema" :args="args" @disable="disableInput" @enable="enableInput"></attached-button>
   </ui-select>
+  <!-- todo: there's a "no-results" slot in ui-select, should we maybe use that? -->
   <span v-else class="editor-no-options">{{ label }}: No options available on current site.</span>
 </template>
 
@@ -89,37 +94,58 @@
     props: ['name', 'data', 'schema', 'args'],
     data() {
       return {
-        options: [],
+        listOptions: [],
         isDisabled: false
       };
     },
     mounted() {
       if(this.args.list){
         this.fetchListItems().then( listItems => {
-          this.setOptions(listItems);
-        });
-      } else {
-        this.setOptions();
+          this.listOptions = listItems;
+        }); // todo: ".catch"?
       }
     },
     computed: {
-      safeData() {
-        if (_.isString(this.data)) {
-          return _.find(this.options, (option) => option.value === this.data);
-        } else if (_.isObject(this.data) && !_.isEmpty(this.data)) {
-          return _.reduce(this.options, (safeArray, option) => {
-            if (this.data[option.value] === true) {
-              return safeArray.concat([option]);
-            } else {
-              return safeArray;
-            }
-          }, []);
+      keys () {
+        return {
+          label: 'name', // backwards compatibility I guess?
+          value: 'value',
+          ...this.args.keys
+        }
+      },
+      NULL_OPTION () {
+        return {
+          [this.keys.label]: 'None',
+          [this.keys.value]: null,
+        }
+      }, 
+      // combine arg/prop options, fetched list options, and a null option for non-multiple selects
+      options () {
+        const propOptions = (this.args.options || [])
+        let opts = propOptions.concat(this.listOptions)
+        if (opts.length > 0) {
+          if (!this.args.multiple) {
+            opts = [ this.NULL_OPTION, ...opts ]
+          }
+          opts = opts.map(this.formatOptionForInput)
+        }
+        return opts
+      },
+      // convert store data into a format suitable for Keen UiSelect.value prop
+      value () {
+        if (!this.data) {
+          // defaults to pass Keen's type check
+          return this.args.multiple ? [] : {}
+        } else if (this.args.storeRawData) {
+          return this.data
         } else {
-          return this.args.multiple ? [] : { value: null, label: 'None' };
+          return (this.args.multiple)
+            ? this.options.filter(o => this.data.includes(o.value))
+            : this.options.find(o => this.data === o.value)
         }
       },
       hasOptions() {
-        return this.options.length > 1 || this.args.list; // the first (blank) option is automatically added
+        return (this.options.length > 0);
       },
       isRequired() {
         return _.get(this.args, 'validate.required') === true || shouldBeRequired(this.args.validate, this.$store, this.name);
@@ -135,56 +161,47 @@
       }
     },
     methods: {
-      update(option) {
-        if (_.isArray(option)) {
-          // set all existing options in data to false
-          const newData = _.mapValues(_.cloneDeep(this.data), () => false);
-
-          // for each of the selected options, set the related key in the data to true
-          _.forEach(option, (o) => newData[o.value] = true);
-
-          this.$store.commit(UPDATE_FORMDATA, { path: this.name, data: newData });
-        } else if (_.isObject(option)) {
-          // single new checked option
-          this.$store.commit(UPDATE_FORMDATA, { path: this.name, data: option.value });
+      // input may be stored as simply a value (scalar) or the entire input object
+      formatOptionForStore (o) {
+        if (_.isObject(o) && !this.args.storeRawData) {
+          return o[this.keys.value]
+        } else {
+          return o
         }
       },
+      // basically, all input takes the object form
+      formatOptionForInput (o) {
+        // start-case labels for scalar options
+        if (_.isString(o) || _.isNumber(o)) {
+          return {
+            [this.keys.value]: o,
+            [this.keys.label]: _.startCase(o)
+          };
+        } else {
+          return o
+        }
+      },
+      handleInput (value) {
+        const data = (this.args.multiple)
+          ? value.map(this.formatOptionForStore)
+          : this.formatOptionForStore(value)
+        this.$store.commit(UPDATE_FORMDATA, { path: this.name, data });
+      },
       fetchListItems() {
+        // todo: look into "loading" prop for UiSelect
         const listName = this.args.list,
           lists = this.$store.state.lists,
-          items = _.get(lists, `${listName}.items`);
+          list = _.get(lists, listName, {});
         let promise;
 
-        if (items) {
-          promise = Promise.resolve(items);
+        // todo: hmm i feel like we could use a light wrapper for this list retrieval business
+        if (list.items && !list.isLoading && !list.error) {
+          promise = Promise.resolve(list.items);
         } else {
-          promise = this.$store.dispatch('getList', listName).then(() => _.get(lists, `${listName}.items`));
+          promise = this.$store.dispatch('getList', listName).then(() => lists[listName].items);
         }
 
         return promise;
-      },
-      setOptions(listItems = []) {
-        const currentSlug = _.get(this.$store, 'state.site.slug');
-
-        let allOptions = (this.args.options || []).concat(listItems || []);
-
-        allOptions = [{
-          value: null,
-          label: 'None'
-          }].concat(_.map(filterBySite(allOptions, currentSlug), (option) => {
-          if (_.isString(option)) {
-            return {
-              value: option,
-              label: _.startCase(option)
-            };
-          } else {
-            return {
-              value: option.value,
-              label: option.name
-            };
-          }
-        }));
-        this.options = allOptions;
       },
       disableInput() {
         this.isDisabled = true;

--- a/lib/page-state/actions.js
+++ b/lib/page-state/actions.js
@@ -10,7 +10,7 @@ import { searchRoute, replaceVersion } from '../utils/references';
 const postPageList = _.debounce((endpoint, data, store) => {
   return postJSON(endpoint, data).then((response) => {
     store.commit(UPDATE_PAGE_STATE, response.value);
-  });
+  }).catch(console.error);
 }, 500); // only update the page list every 500ms
 
 /**


### PR DESCRIPTION
Check out the corresponding branch for Slate or just make the schema changes locally: https://github.com/slategroup/slate-redux/compare/kiln-5...kiln-5-sections-and-rubrics-for-articles?expand=1#diff-ce33edd24382d8d176d9ce24319d550dL252

Rebuild it all and try editing/saving rubrics and sections on an article page, I'll add a few more comments inline.